### PR TITLE
Allow creating caches from an existing client

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -29,6 +29,11 @@ func NewCache[T any](config hazelcast.Config) (*Cache[T], error) {
 	return &Cache[T]{ctx: ctx, client: client}, nil
 }
 
+func NewCacheWithClient[T any](client *hazelcast.Client) *Cache[T] {
+	var ctx = context.Background()
+	return &Cache[T]{ctx, client}
+}
+
 func (c *Cache[T]) Put(mapName string, key string, value T) error {
 	mp, err := c.client.GetMap(c.ctx, mapName)
 	if err != nil {
@@ -112,4 +117,12 @@ func (c *Cache[T]) GetQuery(mapName string, query predicate.Predicate) ([]T, err
 	}
 
 	return unmarshalledValues, nil
+}
+
+func (c *Cache[T]) GetClient() *hazelcast.Client {
+	return c.client
+}
+
+func (c *Cache[T]) GetMap(mapName string) (*hazelcast.Map, error) {
+	return c.client.GetMap(c.ctx, mapName)
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -41,6 +41,12 @@ func TestNewCache(t *testing.T) {
 	assertions.Nil(err)
 }
 
+func TestNewCacheWithClient(t *testing.T) {
+	var assertions = assert.New(t)
+	var cacheWithSameClient = NewCacheWithClient[TestDummy](cache.client)
+	assertions.Equal(cache.client, cacheWithSameClient.client)
+}
+
 func TestCache_Put(t *testing.T) {
 	var assertions = assert.New(t)
 	var dummy = TestDummy{

--- a/test/docker.go
+++ b/test/docker.go
@@ -61,7 +61,7 @@ func StopDocker() {
 func setupHazelcast() {
 	var err error
 	hazelcastContainer, err = pool.RunWithOptions(&dockertest.RunOptions{
-		Name:         "horizon2go-hazelcast",
+		Name:         "horizon-go-hazelcast",
 		Repository:   hazelcastImage,
 		Tag:          hazelcastTag,
 		ExposedPorts: []string{"5701/tcp"},


### PR DESCRIPTION
This PR contains the following changes:
- Add functions to create a new cache with an existing hazelcast client
- Add function to directly retrieve a map from a cache