### PR TITLE
Add cache entry listener

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -103,7 +103,6 @@ func TestCache_AddListener(t *testing.T) {
 	mp, err := cache.client.GetMap(cache.ctx, "testMap")
 	assertions.NoError(err)
 
-	// Add
 	testData := &resource.SubscriptionResource{
 		Spec: struct {
 			Subscription resource.Subscription `json:"subscription"`
@@ -124,7 +123,6 @@ func TestCache_AddListener(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	assertions.True(listener.onAddCalled)
 
-	// Update
 	testDataUpdate := &resource.SubscriptionResource{
 		Spec: struct {
 			Subscription resource.Subscription `json:"subscription"`
@@ -146,7 +144,6 @@ func TestCache_AddListener(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	assertions.True(listener.onUpdateCalled)
 
-	// Remove
 	err = mp.Delete(cache.ctx, "key1")
 	assertions.NoError(err)
 	time.Sleep(2 * time.Second)

--- a/cache/listener.go
+++ b/cache/listener.go
@@ -1,3 +1,7 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package cache
 
 import "github.com/hazelcast/hazelcast-go-client"

--- a/cache/listener.go
+++ b/cache/listener.go
@@ -4,6 +4,7 @@ import "github.com/hazelcast/hazelcast-go-client"
 
 type Listener[T any] interface {
 	OnAdd(event *hazelcast.EntryNotified, obj T)
-	OnUpdate(event *hazelcast.EntryNotified, obj T)
-	OnDelete(event *hazelcast.EntryNotified, obj T)
+	OnUpdate(event *hazelcast.EntryNotified, obj T, oldObj T)
+	OnDelete(event *hazelcast.EntryNotified)
+	OnError(event *hazelcast.EntryNotified, err error)
 }

--- a/cache/listener.go
+++ b/cache/listener.go
@@ -1,0 +1,9 @@
+package cache
+
+import "github.com/hazelcast/hazelcast-go-client"
+
+type Listener[T any] interface {
+	OnAdd(event *hazelcast.EntryNotified, obj T)
+	OnUpdate(event *hazelcast.EntryNotified, obj T)
+	OnDelete(event *hazelcast.EntryNotified, obj T)
+}

--- a/cache/listener_test.go
+++ b/cache/listener_test.go
@@ -2,14 +2,14 @@ package cache
 
 import (
 	"github.com/hazelcast/hazelcast-go-client"
-	"github.com/telekom/pubsub-horizon-go/resource"
-	"log"
 )
 
-type MockListener[T resource.SubscriptionResource] struct {
+type MockListener[T TestDummy] struct {
 	onAddCalled    bool
 	onUpdateCalled bool
 	onDeleteCalled bool
+	onErrorCalled  bool
+	err            error
 }
 
 func (m *MockListener[T]) OnAdd(event *hazelcast.EntryNotified, obj TestDummy) {
@@ -25,6 +25,6 @@ func (m *MockListener[T]) OnDelete(event *hazelcast.EntryNotified) {
 }
 
 func (m *MockListener[T]) OnError(event *hazelcast.EntryNotified, err error) {
-	log.Printf("%v\n", err)
-	panic(err)
+	m.onErrorCalled = true
+	m.err = err
 }

--- a/cache/listener_test.go
+++ b/cache/listener_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/telekom/pubsub-horizon-go/resource"
+	"log"
 )
 
 type MockListener[T resource.SubscriptionResource] struct {
@@ -15,10 +16,15 @@ func (m *MockListener[T]) OnAdd(event *hazelcast.EntryNotified, obj TestDummy) {
 	m.onAddCalled = true
 }
 
-func (m *MockListener[T]) OnUpdate(event *hazelcast.EntryNotified, obj TestDummy) {
+func (m *MockListener[T]) OnUpdate(event *hazelcast.EntryNotified, obj TestDummy, oldObj TestDummy) {
 	m.onUpdateCalled = true
 }
 
-func (m *MockListener[T]) OnDelete(event *hazelcast.EntryNotified, obj TestDummy) {
+func (m *MockListener[T]) OnDelete(event *hazelcast.EntryNotified) {
 	m.onDeleteCalled = true
+}
+
+func (m *MockListener[T]) OnError(event *hazelcast.EntryNotified, err error) {
+	log.Printf("%v\n", err)
+	panic(err)
 }

--- a/cache/listener_test.go
+++ b/cache/listener_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package cache
 
 import (

--- a/cache/listener_test.go
+++ b/cache/listener_test.go
@@ -1,0 +1,24 @@
+package cache
+
+import (
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/telekom/pubsub-horizon-go/resource"
+)
+
+type MockListener[T resource.SubscriptionResource] struct {
+	onAddCalled    bool
+	onUpdateCalled bool
+	onDeleteCalled bool
+}
+
+func (m *MockListener[T]) OnAdd(event *hazelcast.EntryNotified, obj TestDummy) {
+	m.onAddCalled = true
+}
+
+func (m *MockListener[T]) OnUpdate(event *hazelcast.EntryNotified, obj TestDummy) {
+	m.onUpdateCalled = true
+}
+
+func (m *MockListener[T]) OnDelete(event *hazelcast.EntryNotified, obj TestDummy) {
+	m.onDeleteCalled = true
+}


### PR DESCRIPTION
- add new method addListener to react to add, update or delete events in Hazelcast caches
- Add test for addListener method