### PR TITLE
Update statuses of circuit-breaker

### DIFF
--- a/enum/circuit_breaker_status.go
+++ b/enum/circuit_breaker_status.go
@@ -13,16 +13,14 @@ import (
 type CircuitBreakerStatus string
 
 const (
-	CircuitBreakerStatusOpen         = "OPEN"
-	CircuitBreakerStatusRepublishing = "REPUBLISHING"
-	CircuitBreakerStatusCooldown     = "COOLDOWN"
-	CircuitBreakerStatusChecking     = "CHECKING"
+	CircuitBreakerStatusOpen   = "OPEN"
+	CircuitBreakerStatusClosed = "CLOSED"
 )
 
 func ParseCircuitBreakerStatus(s string) (CircuitBreakerStatus, error) {
 	switch CircuitBreakerStatus(s) {
 
-	case CircuitBreakerStatusOpen, CircuitBreakerStatusRepublishing, CircuitBreakerStatusCooldown, CircuitBreakerStatusChecking:
+	case CircuitBreakerStatusOpen, CircuitBreakerStatusClosed:
 		return CircuitBreakerStatus(s), nil
 
 	default:

--- a/enum/circuit_breaker_status_test.go
+++ b/enum/circuit_breaker_status_test.go
@@ -16,9 +16,7 @@ func TestParseCircuitBreakerStatus(t *testing.T) {
 		ExpectError bool
 	}{
 		{"OPEN", CircuitBreakerStatusOpen, false},
-		{"REPUBLISHING", CircuitBreakerStatusRepublishing, false},
-		{"COOLDOWN", CircuitBreakerStatusCooldown, false},
-		{"CHECKING", CircuitBreakerStatusChecking, false},
+		{"CLOSED", CircuitBreakerStatusClosed, false},
 		{"INVALID", "", true},
 	}
 
@@ -40,9 +38,7 @@ func TestCircuitBreakerStatus_UnmarshalJSON(t *testing.T) {
 		ExpectError bool
 	}{
 		{"OPEN", CircuitBreakerStatusOpen, false},
-		{"REPUBLISHING", CircuitBreakerStatusRepublishing, false},
-		{"COOLDOWN", CircuitBreakerStatusCooldown, false},
-		{"CHECKING", CircuitBreakerStatusChecking, false},
+		{"CLOSED", CircuitBreakerStatusClosed, false},
 		{"INVALID", "", true},
 	}
 
@@ -67,9 +63,7 @@ func TestCircuitBreakerStatus_MarshalJSON(t *testing.T) {
 		Expected string
 	}{
 		{CircuitBreakerStatusOpen, `"OPEN"`},
-		{CircuitBreakerStatusRepublishing, `"REPUBLISHING"`},
-		{CircuitBreakerStatusCooldown, `"COOLDOWN"`},
-		{CircuitBreakerStatusChecking, `"CHECKING"`},
+		{CircuitBreakerStatusClosed, `"CLOSED"`},
 	}
 
 	for _, input := range inputs {


### PR DESCRIPTION
This PR updates the statuses a circuit breaker can have to `OPEN` or `CLOSED` and removes the unused statuses.