### PR TITLE
Add the event-type to the circuit-breaker message

### DIFF
--- a/message/circuit_breaker_message.go
+++ b/message/circuit_breaker_message.go
@@ -11,6 +11,7 @@ import (
 
 type CircuitBreakerMessage struct {
 	SubscriptionId    string                    `json:"subscriptionId"`
+	EventType         string                    `json:"eventType"`
 	LastModified      time.Time                 `json:"lastModified"`
 	OriginMessageId   string                    `json:"originMessageId"`
 	Status            enum.CircuitBreakerStatus `json:"status"`


### PR DESCRIPTION
This PR implements an additional field for the event-type within the circuit-breaker-message.