### PR TITLE
Add a custom timestamp type that enforces the RFC3339 format in JSON

### DIFF
--- a/message/circuit_breaker_message.go
+++ b/message/circuit_breaker_message.go
@@ -16,6 +16,6 @@ type CircuitBreakerMessage struct {
 	LastModified      time.Time                 `json:"lastModified"`
 	OriginMessageId   string                    `json:"originMessageId"`
 	Status            enum.CircuitBreakerStatus `json:"status"`
-	LastRepublished   time.Time                 `json:"lastRepublished"`
+	LastRepublished   time.Time                 `json:"lastRepublished,omitempty"`
 	RepublishingCount int                       `json:"republishingCount"`
 }

--- a/message/circuit_breaker_message.go
+++ b/message/circuit_breaker_message.go
@@ -6,16 +6,16 @@ package message
 
 import (
 	"github.com/telekom/pubsub-horizon-go/enum"
-	"time"
+	"github.com/telekom/pubsub-horizon-go/types"
 )
 
 type CircuitBreakerMessage struct {
 	SubscriptionId    string                    `json:"subscriptionId"`
 	Environment       string                    `json:"environment"`
 	EventType         string                    `json:"eventType"`
-	LastModified      time.Time                 `json:"lastModified"`
+	LastModified      *types.Timestamp          `json:"lastModified"`
 	OriginMessageId   string                    `json:"originMessageId"`
 	Status            enum.CircuitBreakerStatus `json:"status"`
-	LastRepublished   time.Time                 `json:"lastRepublished,omitempty"`
+	LastRepublished   *types.Timestamp          `json:"lastRepublished,omitempty"`
 	RepublishingCount int                       `json:"republishingCount"`
 }

--- a/types/timestamp.go
+++ b/types/timestamp.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Timestamp time.Time
+
+func NewTimestamp(time time.Time) *Timestamp {
+	var timestamp = Timestamp(time)
+	return &timestamp
+}
+
+func (c *Timestamp) MarshalJSON() ([]byte, error) {
+	var current = time.Time(*c)
+
+	var s = fmt.Sprintf(`"%s"`, current.Format(time.RFC3339))
+	return []byte(s), nil
+}
+
+func (c *Timestamp) UnmarshalJSON(bytes []byte) error {
+	var data = string(bytes)
+	var parsedTime time.Time
+	var err error
+
+	if data == "null" {
+		parsedTime = time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+		*c = Timestamp(parsedTime)
+		return nil
+	}
+
+	if strings.HasPrefix(data, `"`) && strings.HasSuffix(data, `"`) {
+		data, _ = strconv.Unquote(data)
+	}
+
+	parsedTime, err = time.Parse(time.RFC3339, data)
+	if err != nil {
+		return err
+	}
+
+	*c = Timestamp(parsedTime)
+	return nil
+}
+
+func (c *Timestamp) ToTime() time.Time {
+	return time.Time(*c)
+}

--- a/types/timestamp.go
+++ b/types/timestamp.go
@@ -1,3 +1,7 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (

--- a/types/timestamp_test.go
+++ b/types/timestamp_test.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreakerTime_MarshalJSON(t *testing.T) {
+	var assertions = assert.New(t)
+	var dummyTime = time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	bytes, err := dummyTime.MarshalJSON()
+	assertions.NoError(err)
+	assertions.Equal(`"0001-01-01T00:00:00Z"`, string(bytes))
+}
+
+func TestCircuitBreakerTime_UnmarshalJSON(t *testing.T) {
+	var assertions = assert.New(t)
+	var expectation = time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+	var bytes = []byte(`{"time": "0001-01-01T00:00:00Z"}`)
+
+	var dummy = struct {
+		Timestamp Timestamp `json:"time"`
+	}{}
+
+	assertions.NoError(json.Unmarshal(bytes, &dummy))
+
+	var unmarshalledTime = dummy.Timestamp.ToTime()
+	assertions.True(unmarshalledTime.Equal(expectation))
+}

--- a/types/timestamp_test.go
+++ b/types/timestamp_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package types
 
 import (


### PR DESCRIPTION
This PR introduces the Timestamp type that marshals/unmarshals from/to RFC3339 compliant strings when using JSON.