### PR TITLE
Add bson tags to StatusMessage

### DIFF
--- a/message/status.go
+++ b/message/status.go
@@ -11,43 +11,43 @@ import (
 
 type StatusMessage struct {
 	StateError
-	Uuid                     string                  `json:"uuid"`
-	Coordinates              *Coordinates            `json:"coordinates"`
-	Status                   enum.MessageStatus      `json:"status"`
-	Environment              string                  `json:"environment"`
-	DeliveryType             enum.DeliveryType       `json:"deliveryType"`
-	SubscriptionId           string                  `json:"subscriptionId"`
-	Event                    EventDetails            `json:"event"`
-	Properties               map[string]any          `json:"properties"`
-	MultiplexedFrom          string                  `json:"multiplexedFrom"`
-	EventRetentionTime       enum.EventRetentionTime `json:"eventRetentionTime"`
-	Topic                    string                  `json:"topic"`
-	Timestamp                time.Time               `json:"timestamp"`
-	Modified                 time.Time               `json:"modified"`
-	AppliedScopes            []string                `json:"appliedScopes"`
-	ScopeEvaluationResult    EvaluationResult        `json:"scopeEvaluationResult"`
-	ConsumerEvaluationResult EvaluationResult        `json:"consumerEvaluationResult"`
+	Uuid                     string                  `json:"uuid" bson:"_id"`
+	Coordinates              *Coordinates            `json:"coordinates" bson:"coordinates"`
+	Status                   enum.MessageStatus      `json:"status" bson:"status"`
+	Environment              string                  `json:"environment" bson:"environment"`
+	DeliveryType             enum.DeliveryType       `json:"deliveryType" bson:"deliveryType"`
+	SubscriptionId           string                  `json:"subscriptionId" bson:"subscriptionId"`
+	Event                    EventDetails            `json:"event" bson:"event"`
+	Properties               map[string]any          `json:"properties" bson:"properties"`
+	MultiplexedFrom          string                  `json:"multiplexedFrom" bson:"multiplexedFrom"`
+	EventRetentionTime       enum.EventRetentionTime `json:"eventRetentionTime" bson:"eventRetentionTime"`
+	Topic                    string                  `json:"topic" bson:"topic"`
+	Timestamp                time.Time               `json:"timestamp" bson:"timestamp"`
+	Modified                 time.Time               `json:"modified" bson:"modified"`
+	AppliedScopes            []string                `json:"appliedScopes" bson:"appliedScopes"`
+	ScopeEvaluationResult    EvaluationResult        `json:"scopeEvaluationResult" bson:"scopeEvaluationResult"`
+	ConsumerEvaluationResult EvaluationResult        `json:"consumerEvaluationResult" bson:"consumerEvaluationResult"`
 }
 
 type Coordinates struct {
-	Partition *int32 `json:"partition"`
-	Offset    *int64 `json:"offset"`
+	Partition *int32 `json:"partition" bson:"partition"`
+	Offset    *int64 `json:"offset" bson:"offset"`
 }
 
 type EventDetails struct {
-	Id   string    `json:"id"`
-	Type string    `json:"type"`
-	Time time.Time `json:"time"`
+	Id   string    `json:"id" bson:"id"`
+	Type string    `json:"type" bson:"type"`
+	Time time.Time `json:"time" bson:"time"`
 }
 
 type StateError struct {
-	ErrorMessage string `json:"errorMessage,omitempty"`
-	ErrorType    string `json:"errorType,omitempty"`
+	ErrorMessage string `json:"errorMessage,omitempty" bson:"errorMessage,omitempty"`
+	ErrorType    string `json:"errorType,omitempty" bson:"errorType,omitempty"`
 }
 
 type EvaluationResult struct {
-	OperatorName     string             `json:"operatorName"`
-	Match            bool               `json:"match"`
-	CauseDescription string             `json:"causeDescription"`
-	ChildOperators   []EvaluationResult `json:"childOperators"`
+	OperatorName     string             `json:"operatorName" bson:"operatorName"`
+	Match            bool               `json:"match" bson:"match"`
+	CauseDescription string             `json:"causeDescription" bson:"causeDescription"`
+	ChildOperators   []EvaluationResult `json:"childOperators" bson:"childOperators"`
 }


### PR DESCRIPTION
This PR adds additional `bson` tags to the StatusMessage to allow direct decoding from MongoDB results.